### PR TITLE
Add statuses

### DIFF
--- a/lib/sidekiq/health/queue_status.rb
+++ b/lib/sidekiq/health/queue_status.rb
@@ -2,7 +2,72 @@ require 'sidekiq/api'
 
 module Sidekiq
   module Health
+    MAXIMUM_HEALTHY_QUEUE_SIZE = 50
+    MAXIMUM_HEALTHY_DEAD_SET_LAST_HOUR_SIZE = 5
+
     class QueueStatus
+      class Status
+        def initialize(queue_name, dead_set)
+          @queue_name = queue_name
+          @dead_set = dead_set
+        end
+
+        attr_reader :queue_name
+
+        def total_number_of_jobs
+          sidekiq_queue.size
+        end
+
+        def total_number_of_failed_jobs
+          dead_set.size
+        end
+
+        def total_number_of_failed_jobs_since(timestamp)
+          dead_set.select { |item| item['failed_at'] > timestamp.to_r }.size
+        end
+
+        def number_of_scheduled_jobs_per_class_name
+          @number_of_scheduled_jobs_per_class_name ||= sidekiq_queue.inject({}) do |job_pool, scheduled_job|
+            wrapped_class = scheduled_job['wrapped']
+            job_pool[wrapped_class] = job_pool.fetch(wrapped_class, 0) + 1
+            job_pool
+          end
+            .sort_by { |job_name, count| count }
+            .to_h
+        end
+
+        def health_as_human_readable_string
+          health = []
+
+          if total_number_of_jobs > Sidekiq::Health::MAXIMUM_HEALTHY_QUEUE_SIZE
+            more_than_allowed = total_number_of_jobs - Sidekiq::Health::MAXIMUM_HEALTHY_QUEUE_SIZE
+            health << "There are a total of #{total_number_of_jobs} scheduled jobs, "\
+              "which is #{more_than_allowed} more than healthy."
+          end
+
+          dead_in_last_hour = total_number_of_failed_jobs_since(1.hour.ago)
+          if dead_in_last_hour > Sidekiq::Health::MAXIMUM_HEALTHY_DEAD_SET_LAST_HOUR_SIZE
+            more_than_allowed = dead_in_last_hour - Sidekiq::Health::MAXIMUM_HEALTHY_DEAD_SET_LAST_HOUR_SIZE
+            health << "There are a total of #{dead_in_last_hour} failed jobs, "\
+              "which is #{more_than_allowed} more than healthy."
+          end
+
+          if health.empty?
+            health << "Everything looks good."
+          end
+
+          health.join(" ")
+        end
+
+        private
+
+        attr_reader :dead_set
+
+        def sidekiq_queue
+          @sidekiq_queue ||= Sidekiq::Queue.new queue_name
+        end
+      end
+
       def print
         output = ""
 
@@ -14,6 +79,16 @@ module Sidekiq
         output
       end
 
+      def statuses
+        Sidekiq::DeadSet.new
+
+        queue_names.map do |name|
+          Status.new \
+            name,
+            dead_set_for(queue_name: name)
+        end
+      end
+
       private
 
       def queue_size(name)
@@ -23,11 +98,20 @@ module Sidekiq
       def queue_names
         Sidekiq::Health::QueueNames.new.get
       end
+
+      def dead_set_for(queue_name:)
+        all_dead_jobs.fetch(queue_name, [])
+      end
+
+      def all_dead_jobs
+        @all_dead_jobs ||= Sidekiq::DeadSet.new.inject({}) do |all_jobs, item|
+          all_jobs[item.queue] = all_jobs.fetch(item.queue, []) + [item]
+          all_jobs
+        end
+      end
     end
 
     class QueueHealthFormatter
-      QUEUE_SIZE_WARNING_THRESHOLD = 50
-
       attr_reader :name, :size
 
       def initialize(name, size)
@@ -36,11 +120,15 @@ module Sidekiq
       end
 
       def to_s
-        if size < QUEUE_SIZE_WARNING_THRESHOLD
+        if healthy?
           "OK. #{queue_information}"
         else
           "WARNING: TOO MANY JOBS ENQUEUED. #{queue_information}"
         end
+      end
+
+      def healthy?
+        size < Sidekiq::Health::MAXIMUM_HEALTHY_QUEUE_SIZE
       end
 
       private

--- a/lib/sidekiq/health/queue_status.rb
+++ b/lib/sidekiq/health/queue_status.rb
@@ -80,8 +80,6 @@ module Sidekiq
       end
 
       def statuses
-        Sidekiq::DeadSet.new
-
         queue_names.map do |name|
           Status.new \
             name,


### PR DESCRIPTION
This commit adds .statuses function, which essentially returns a list of
all Sidekiq queues wrapped in a class. This class adds a bunch of helper
methods, intended to make it easy to query for the health of your queue.

Note that this helper makes a "snapshot" of the time that the status is
constructed. Since the content of a Sidekiq queue changes quite often,
it is necessary to make frequent snapshots for a real-time monitor.
